### PR TITLE
Basic HAL-Forms support.

### DIFF
--- a/src/components/resource.ts
+++ b/src/components/resource.ts
@@ -13,7 +13,7 @@ import pager from './pager';
  */
 export default async function resource(ctx: Context, body: any, links: Link[], options: SureOptions) {
 
-  const formsHtml = forms(links, options);
+  const formsHtml = forms(ctx, links, options);
   const linksHtml = linksTable(links, options);
 
   return `

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export const supportedContentTypes = [
   'application/problem+json',
   'text/markdown',
   'text/csv',
+  'application/prs.hal-forms+json'
 ];
 
 /*


### PR DESCRIPTION
This change implements some of hal-forms, described here:
https://rwcbook.github.io/hal-forms/

This makes it possible to make very basic forms on APIs. We're probably
going to get some real-world experience with it before implementing
other bits.

Some issues with hal-forms that make it not ideal yet are:

* It only really maps to 1 HTML form type: text, so that's all we
  support for now.
* There's no way to encode a 'target' for the form in JSON. It expects
  that a client *knows* what the target will be when it fetches a form.
  It's possible to embed a target with the _htarget query parameter
  (which we support), but this makes it kinda weird.
* It also sort of expects the client to fetch the current values via
  the _hdoc argument. hal-browser is a client in this context, but it
  doesn't have the ability yet to get the state to prepopulate it.
* Even though hal-forms supports `application/json`, it will be ignored
  because hal-browser does not yet ship with any javascript. Browsers
  will just default to `application/x-www-form-urlencoded`. The intent
  is to add a small javascript utility in the future that scans the HTML
  doc for any `<form>` element with `enctype="application/json"`,
  intercept those forms, and submit the form via javascript instead.
* The 'templated' property is not supported on properties (form fields).
  The specification doesn't really describe what their purpose are or
  what should be done with them, so for now we're just ignoring them.

So yea, this is a beta feature allowing the creation of pretty simple
forms in an existing api. We're probably going to look at Dwolla forms
as well, as it's a more complete spec that's a better fit for this
project.